### PR TITLE
add verbose option for publishing

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -14,3 +14,4 @@ jobs:
           remote: staging
           workdir: ./example
           app_url: publish.fissionapp.net
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Copy the resulting value into Github Secrets for your project (or run `gh secret
 
 *Optional* Set the remote (Fission API endpoint) to use (leave this blank unless you know you need it.).
 
+### `verbose`
+
+*Optional* Enables verbose output from the fission CLI (useful for debugging publishing errors).
+
 ## Outputs 
 
 ### `app_url`

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   remote:
     description: "The remote environment to use for API calls."
     required: false
+  verbose:
+    description: "Run fission CLI commands in verbose mode (good for debugging)."
+    required: false
 outputs:
   app_url:
     description: "App URL for the published app."


### PR DESCRIPTION
Allows a `verbose` input to enable `--verbose` mode for all CLI commands.

Fixes #5 