### PR TITLE
Bump CLI to 2.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ENV CLI_VERSION 2.15.0
+ENV CLI_VERSION 2.16.1
 ENV CLI_NAME fission-cli-ubuntu-20.04
 ENV LANG=C.UTF-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 ENV CLI_VERSION 2.16.1
-ENV CLI_NAME fission-cli-ubuntu-20.04
+ENV CLI_NAME fission-cli-ubuntu-20.04-x86_64
 ENV LANG=C.UTF-8
 
 RUN apt-get update \


### PR DESCRIPTION
Just what it says on the tin. This CLI includes a fix for submitting a newly-constructed UCAN on every push (including retries after a 502)