### PR TITLE
Fix asset name

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18937,7 +18937,7 @@ const assert = __importStar(__webpack_require__(357));
 const fs = __importStar(__webpack_require__(747));
 const path = __importStar(__webpack_require__(622));
 const utils_1 = __webpack_require__(163);
-const ASSEST_NAME = "fission-cli-ubuntu-20.04-x86_64";
+const ASSEST_NAME = "fission-cli-ubuntu-20.04";
 const getFissionCLI = () => __awaiter(void 0, void 0, void 0, function* () {
     const githubToken = core.getInput("token");
     const octokit = github.getOctokit(githubToken);

--- a/dist/index.js
+++ b/dist/index.js
@@ -18937,7 +18937,7 @@ const assert = __importStar(__webpack_require__(357));
 const fs = __importStar(__webpack_require__(747));
 const path = __importStar(__webpack_require__(622));
 const utils_1 = __webpack_require__(163);
-const ASSEST_NAME = "fission-cli-ubuntu-20.04";
+const ASSET_NAME = "fission-cli-ubuntu-20.04";
 const getFissionCLI = () => __awaiter(void 0, void 0, void 0, function* () {
     const githubToken = core.getInput("token");
     const octokit = github.getOctokit(githubToken);
@@ -18953,7 +18953,7 @@ const getFissionCLI = () => __awaiter(void 0, void 0, void 0, function* () {
     if (!toolPath) {
         // Get the URL for the actual CLI version
         let downloadPath = "";
-        const asset = release.assets.find((a) => a.name == ASSEST_NAME);
+        const asset = release.assets.find((a) => a.name == ASSET_NAME);
         if (asset) {
             downloadPath = yield tc.downloadTool(asset.browser_download_url);
             yield exec.exec("chmod", ["+x", downloadPath]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-action",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "description": "Publish to Fission",
   "main": "lib/index.js",

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -7,7 +7,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { runFission } from "./utils";
 
-const ASSEST_NAME = "fission-cli-ubuntu-20.04";
+const ASSET_NAME = "fission-cli-ubuntu-20.04";
 
 export const getFissionCLI = async () => {
   const githubToken = core.getInput("token");
@@ -27,7 +27,7 @@ export const getFissionCLI = async () => {
   if (!toolPath) {
     // Get the URL for the actual CLI version
     let downloadPath = "";
-    const asset = release.assets.find((a) => a.name == ASSEST_NAME);
+    const asset = release.assets.find((a) => a.name == ASSET_NAME);
     if (asset) {
       downloadPath = await tc.downloadTool(asset.browser_download_url);
       await exec.exec("chmod", ["+x", downloadPath]);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -7,7 +7,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { runFission } from "./utils";
 
-const ASSEST_NAME = "fission-cli-ubuntu-20.04-x86_64";
+const ASSEST_NAME = "fission-cli-ubuntu-20.04";
 
 export const getFissionCLI = async () => {
   const githubToken = core.getInput("token");


### PR DESCRIPTION
The new fission CLI release uses a different name for the binary (and we can't rename it to the old name, because of a github bug).

I believe this name mismatch causes this issue:
```
Using fission CLI version: 2.17.0
Unable to find release download.
Error: Unable to locate executable file: fission. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```
(from [one of our deploys today](https://github.com/fission-suite/auth-lobby/runs/4236167077?check_suite_focus=true))

Also, I renamed `ASSEST_NAME` to `ASSET_NAME`, if you don't mind :stuck_out_tongue_winking_eye: 